### PR TITLE
ft- API endpoint for delete course

### DIFF
--- a/server/middlewares/validateUpdateCourse.js
+++ b/server/middlewares/validateUpdateCourse.js
@@ -32,7 +32,7 @@ const updateCourseError = (message) => {
     courseAvailability = courseAvailability && courseAvailability.toString().trim();
   
     if (!courseAvailability) return next(updateCourseError('this field cannot be empty. Please provide a value.'));
-    if (courseAvailability !== 'true' || courseAvailability !== 'false') return next(updateCourseError('course availability value can either be true or false.'));
+    if (courseAvailability !== 'true' && courseAvailability !== 'false') return next(updateCourseError('course availability value can either be true or false.'));
     return next();
   };
   export default validateUpdateCourse;

--- a/server/models/course.js
+++ b/server/models/course.js
@@ -40,7 +40,7 @@ export default class Course {
   */
 
   remove(id) {
-    const sql = 'DELETE FROM courses WHERE id = $1';
+    const sql = 'DELETE FROM courses WHERE id = $1 RETURNING *';
     return this.db.one(sql, id);
   }
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,4 +17,6 @@ router.get('/courses',middlewares.verifyUserToken, CourseController.getAllCourse
 router.use('*', middlewares.verifyAdminToken);
 router.post('/courses', middlewares.validatePostCourse, CourseController.postCourse);
 router.patch('/courses/:id', middlewares.validateUpdateCourse, CourseController.updateCourse);
+router.delete('/courses/:id', CourseController.deleteCourse);
+
 export default router;


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint for deleting a subject course from the database.

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`DELETE /api/v1/courses/<courseId>`

**How should this be manually tested?**
- Clone the repo using git clone `https://github.com/akinyeleolat/computer-based-test.git.`
- run `git checkout ft-delete-course`
- run `npm install` and `npm start`.
- `npm run migrate`
- `using postman`
![screenshot 254](https://user-images.githubusercontent.com/38490848/47781026-0431a880-dcfd-11e8-8dfb-614ffcec2f18.png)


